### PR TITLE
Fix CPF validation

### DIFF
--- a/library/src/main/java/br/com/ilhasoft/support/validation/rule/CpfTypeRule.java
+++ b/library/src/main/java/br/com/ilhasoft/support/validation/rule/CpfTypeRule.java
@@ -16,7 +16,7 @@ public class CpfTypeRule extends TypeRule {
     @Override
     protected boolean isValid(TextView view) {
         final String rawCpf = view.getText().toString().trim().replaceAll("[^\\d]", "");
-        return rawCpf.length() == 11
+        return rawCpf.length() == 11 && !onBlackList(rawCpf)
                 && (cpfDv(rawCpf, 1) == Character.getNumericValue(rawCpf.charAt(9))
                 && cpfDv(rawCpf, 2) == Character.getNumericValue(rawCpf.charAt(10)));
     }
@@ -40,6 +40,17 @@ public class CpfTypeRule extends TypeRule {
             sum += ((baseMultiplier - i) * Character.getNumericValue(rawCPF.charAt(i)));
         }
         return sum;
+    }
+
+    // Reference: https://github.com/concretesolutions/canarinho/blob/master/canarinho/src/main/java/br/com/concretesolutions/canarinho/validator/ValidadorCPF.java
+    private boolean onBlackList(String rawCpf) {
+        boolean equal = true;
+        for (int i = 1; i < 11 && equal; i++) {
+            if (rawCpf.charAt(i) != rawCpf.charAt(0)) {
+                equal = false;
+            }
+        }
+        return equal || rawCpf.equals("12345678909");
     }
 
     @Override


### PR DESCRIPTION
Fix in the validation of the CPFs that are valid for the algorithm of the verifier digit, but are considered invalid by the federal revenue.

Signed-off-by: Daniel San <danielsan@ilhasoft.com.br>