### PR TITLE
Add attribute showErrorMessage to allow validation whilst not showing the message

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,15 @@ By default, the library prompts error messages and doens't dismiss the error aut
   app:validateDateAutoDismiss="@{true}" />
 ```
 
+### Hiding validation messages ###
+
+If you want to check if fields are valid but not have the EditText's error message set, add an attribute:  
+```
+app:showErrorMessage='@{false}'
+```  
+This is useful if you're validating as the user types to enable a button - showing an error after the user has only typed one character is not an ideal user experience. You can use the databinding expression to show the message according to your requirements, such as after onFocusChanged when the user navigates out of the field.
+
+
 ## License ##
 
     Copyright 2017-present Ilhasoft

--- a/library/src/main/java/br/com/ilhasoft/support/validation/binding/ConfigBindings.java
+++ b/library/src/main/java/br/com/ilhasoft/support/validation/binding/ConfigBindings.java
@@ -1,0 +1,25 @@
+package br.com.ilhasoft.support.validation.binding;
+
+import android.databinding.BindingAdapter;
+import android.widget.TextView;
+
+import br.com.ilhasoft.support.validation.R;
+
+/**
+ * Bindings for properties which configure validation behaviour 
+ * 
+ * 
+ * Created by molexx on 12/11/2017.
+ */
+public class ConfigBindings {
+    
+    @BindingAdapter(value = {"showErrorMessage"}, requireAll = false)
+    public static void bindingShowErrorMessage(TextView view, boolean showErrorMessage) {
+        if (showErrorMessage == false) {
+            view.setTag(R.id.show_error_message, Boolean.FALSE);
+        } else {
+            view.setTag(R.id.show_error_message, null);
+        }
+    }
+    
+}

--- a/library/src/main/java/br/com/ilhasoft/support/validation/util/EditTextHandler.java
+++ b/library/src/main/java/br/com/ilhasoft/support/validation/util/EditTextHandler.java
@@ -38,12 +38,15 @@ public class EditTextHandler {
     }
 
     public static void setError(TextView textView, String errorMessage) {
-        TextInputLayout textInputLayout = getTextInputLayout(textView);
-        if (textInputLayout != null) {
-            textInputLayout.setErrorEnabled(!TextUtils.isEmpty(errorMessage));
-            textInputLayout.setError(errorMessage);
-        } else {
-            textView.setError(errorMessage);
+        Boolean b = (Boolean)textView.getTag(R.id.show_error_message);
+        if (!Boolean.FALSE.equals(b)) {
+            TextInputLayout textInputLayout = getTextInputLayout(textView);
+            if (textInputLayout != null) {
+                textInputLayout.setErrorEnabled(!TextUtils.isEmpty(errorMessage));
+                textInputLayout.setError(errorMessage);
+            } else {
+                textView.setError(errorMessage);
+            }
         }
     }
 

--- a/library/src/main/java/br/com/ilhasoft/support/validation/util/EditTextHandler.java
+++ b/library/src/main/java/br/com/ilhasoft/support/validation/util/EditTextHandler.java
@@ -42,10 +42,13 @@ public class EditTextHandler {
         if (!Boolean.FALSE.equals(b)) {
             TextInputLayout textInputLayout = getTextInputLayout(textView);
             if (textInputLayout != null) {
-                textInputLayout.setErrorEnabled(!TextUtils.isEmpty(errorMessage));
-                textInputLayout.setError(errorMessage);
+                if ((TextUtils.isEmpty(errorMessage) && !TextUtils.isEmpty(textInputLayout.getError())) || (errorMessage != null && !errorMessage.equals(textInputLayout.getError()))) {
+                    textInputLayout.setError(errorMessage);
+                }
             } else {
-                textView.setError(errorMessage);
+                if ((TextUtils.isEmpty(errorMessage) && !TextUtils.isEmpty(textView.getError())) || (errorMessage != null && !errorMessage.equals(textView.getError()))) {
+                    textView.setError(errorMessage);
+                }
             }
         }
     }

--- a/library/src/main/res/values/ids.xml
+++ b/library/src/main/res/values/ids.xml
@@ -2,4 +2,5 @@
 <resources>
     <item type="id" name="validator_rule" />
     <item type="id" name="text_watcher_clear_error" />
+    <item type="id" name="show_error_message" />
 </resources>


### PR DESCRIPTION
Implements functionality requested in #13 

The new attribute's expression must resolve to false to have any effect, backward compatibility is maintained for projects that don't mention the attribute.