### PR TITLE
Remove unused attributes from AndroidManifest

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,8 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="br.com.ilhasoft.support.validation">
-
-    <application android:allowBackup="true"
-        android:supportsRtl="true" />
-
-</manifest>
+<manifest
+    package="br.com.ilhasoft.support.validation" />


### PR DESCRIPTION
These would clash with definitions in the including project and create error messages like:

```
Error:Execution failed for task ':app:processAppDebugManifest'.
> Manifest merger failed : Attribute application@allowBackup value=(false) from AndroidManifest.xml:40:9-36
  	is also present at [com.github.Ilhasoft:data-binding-validator:1.0.0] AndroidManifest.xml:12:9-35 value=(true).
  	Suggestion: add 'tools:replace="android:allowBackup"' to <application> element at AndroidManifest.xml:20:5-108:19 to override.
```